### PR TITLE
bugfix: remove user data re-creation with every login

### DIFF
--- a/server/api/apiAuth.js
+++ b/server/api/apiAuth.js
@@ -34,18 +34,15 @@ router.route('/').post((req, res) => {
 
   DBController.getUserByTelegramId(reqUser.id)
     .then(async takenUser => {
-      // const user =
-      //   takenUser === null
-      //     ? await DBController.createNewUser(reqUser)
-      //     : takenUser;
-
-      const user = await DBController.createNewUser({
-        ...reqUser,
-        firstName: reqUser.firstName,
-        lastName: reqUser.lastName,
-        avatar: reqUser.avatar,
-        username: reqUser.username
-      });
+      let user;
+      if (takenUser === null) {
+        user = await DBController.createNewUser(reqUser);
+      } else {
+        user = await DBController.updateUserInfoByUserId(
+          takenUser._id,
+          reqUser
+        );
+      }
 
       let { department } = user || null;
 


### PR DESCRIPTION
Есть небольшой баг, который пока не доставляет больших проблем, но потом может:
при логине существующего пользователя все его поля перезаписываются, потому что используется метод, в котором прописаны настройки по умолчанию:
```
  const createNewUser = user => {
    nullAndUndefinedValidation(user);
    const newUser = {
      firstName: user.first_name,
      lastName: user.last_name,
      telegramId: user.id,
      avatar: user.photo_url,
      username: user.username,
      events: [],
      created: Date.now(),
      banned: { status: false, expired: 0 },
      admin: { permission: 0, password: null }
    };
    return Users.findOneAndUpdate(
      { telegramId: newUser.telegramId },
      { $set: newUser },
      { upsert: true, new: true }
    );
  };
```
В исправленной версии, если пользователь существует, используем метод:
```
  const updateUserInfoByUserId = (_id, info) => {
    nullAndUndefinedValidation(_id, info);
    return Users.findOneAndUpdate(
      { _id },
      {
        $set: {
          firstName: info.first_name,
          lastName: info.last_name,
          avatar: info.photo_url,
          username: info.username
        }
      }
    );
  };
```
который подтягивает изменения, если пользователь изменил поля в аккаунте Телеграма, но при этом не трогает служебные поля а-ля created, admin, banned.